### PR TITLE
Add reexport option and `import ... as ...` flavour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ We are currently working on porting this changelog to the specifications in
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version: 1.3.0 - Unreleased
+
+### Added
+* Added an explicit re-export feature as described in the "Stub Files" section of PEP 484, available via `--reexport` CLI option.
 
 ## Version: 1.2.0 - Released 2025-12-02
 

--- a/mkinit/__init__.py
+++ b/mkinit/__init__.py
@@ -42,7 +42,7 @@ Regenerate Input Command
 mkinit ~/code/mkinit/mkinit
 """
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 __submodules__ = [
     "dynamic_mkinit",

--- a/mkinit/__main__.py
+++ b/mkinit/__main__.py
@@ -94,6 +94,12 @@ def main():
         default=True,
         help="Do not generate an __all__ variable",
     )
+    parser.add_argument(
+        "--reexport",
+        action="store_true",
+        default=False,
+        help="Generate imports in the format 'from <modname> import <object> as <object>'",
+    )
 
     parser.add_argument(
         "--relative",
@@ -211,6 +217,7 @@ def main():
         "lazy_loader_typed": ns["lazy_loader_typed"],
         "lazy_boilerplate": ns["lazy_boilerplate"],
         "use_black": ns["black"],
+        "reexport": ns["reexport"],
     }
 
     diff = ns["diff"]


### PR DESCRIPTION
Reexport options allows to generate imports in format
```
import <module> as <module_name>
from <module> import <object> as <object>
```