### PR TITLE
Compatibility for Python 3.14

### DIFF
--- a/mkinit/static_analysis.py
+++ b/mkinit/static_analysis.py
@@ -23,9 +23,9 @@ def _parse_static_node_value(node):
     Extract a constant value from a node if possible
     """
     # TODO: ast.Constant for 3.8
-    if (isinstance(node, ast.Constant) and isinstance(node.value, (int, float)) if IS_PY_GE_308 else isinstance(node, ast.Num)):
+    if (isinstance(node, ast.Constant) and isinstance(node.value, (int, float)) if IS_PY_GE_308 else isinstance(node, ast.Constant)):
         value = node.value if IS_PY_GE_308 else node.n
-    elif (isinstance(node, ast.Constant) and isinstance(node.value, str) if IS_PY_GE_308 else isinstance(node, ast.Str)):
+    elif (isinstance(node, ast.Constant) and isinstance(node.value, str) if IS_PY_GE_308 else isinstance(node, ast.Constant)):
         value = node.value if IS_PY_GE_308 else node.s
     elif isinstance(node, ast.List):
         value = list(map(_parse_static_node_value, node.elts))
@@ -36,7 +36,7 @@ def _parse_static_node_value(node):
         values = map(_parse_static_node_value, node.values)
         value = OrderedDict(zip(keys, values))
         # value = dict(zip(keys, values))
-    elif isinstance(node, (ast.NameConstant)):
+    elif isinstance(node, (ast.Constant)):
         value = node.value
     else:
         print(node.__dict__)

--- a/mkinit/top_level_ast.py
+++ b/mkinit/top_level_ast.py
@@ -320,23 +320,23 @@ def static_truthiness(node):
         bool or None: True or False if a node can be statically bound to a
         truthy value, otherwise returns None.
     """
-    if (isinstance(node, ast.Constant) and isinstance(node.value, str) if IS_PY_GE_308 else isinstance(node, ast.Str)):
+    if (isinstance(node, ast.Constant) and isinstance(node.value, str) if IS_PY_GE_308 else isinstance(node, ast.Constant)):
         return bool(node.value if IS_PY_GE_308 else node.s)
-    # if isinstance(node, ast.Str):
+    # if isinstance(node, ast.Constant):
     #     return bool(node.s)
     elif isinstance(node, ast.Tuple):
         return bool(node.elts)
-    # elif isinstance(node, ast.Num):
+    # elif isinstance(node, ast.Constant):
     #     return bool(node.n)
-    elif (isinstance(node, ast.Constant) and isinstance(node.value, (int, float)) if IS_PY_GE_308 else isinstance(node, ast.Num)):
+    elif (isinstance(node, ast.Constant) and isinstance(node.value, (int, float)) if IS_PY_GE_308 else isinstance(node, ast.Constant)):
         return bool(node.value if IS_PY_GE_308 else node.n)
-    # elif isinstance(node, ast.Bytes):  # nocover
+    # elif isinstance(node, ast.Constant):  # nocover
     #     return bool(node.s)
-    elif (isinstance(node, ast.Constant) and isinstance(node.value, bytes) if IS_PY_GE_308 else isinstance(node, ast.Bytes)):
+    elif (isinstance(node, ast.Constant) and isinstance(node.value, bytes) if IS_PY_GE_308 else isinstance(node, ast.Constant)):
         return bool(node.value if IS_PY_GE_308 else node.s)
-    # elif isinstance(node, ast.NameConstant):
+    # elif isinstance(node, ast.Constant):
     #     return bool(node.value)
-    elif (isinstance(node, ast.Constant) if IS_PY_GE_308 else isinstance(node, ast.NameConstant)):
+    elif (isinstance(node, ast.Constant) if IS_PY_GE_308 else isinstance(node, ast.Constant)):
         return bool(node.value)
     else:
         return _UNHANDLED

--- a/mkinit/util/util_import.py
+++ b/mkinit/util/util_import.py
@@ -28,9 +28,9 @@ def _parse_static_node_value(node):
     import ast
     from collections import OrderedDict
     import numbers
-    if (isinstance(node, ast.Constant) and isinstance(node.value, numbers.Number) if IS_PY_GE_308 else isinstance(node, ast.Num)):
+    if (isinstance(node, ast.Constant) and isinstance(node.value, numbers.Number) if IS_PY_GE_308 else isinstance(node, ast.Constant)):
         value = node.value if IS_PY_GE_308 else node.n
-    elif (isinstance(node, ast.Constant) and isinstance(node.value, str) if IS_PY_GE_308 else isinstance(node, ast.Str)):
+    elif (isinstance(node, ast.Constant) and isinstance(node.value, str) if IS_PY_GE_308 else isinstance(node, ast.Constant)):
         value = node.value if IS_PY_GE_308 else node.s
     elif isinstance(node, ast.List):
         value = list(map(_parse_static_node_value, node.elts))
@@ -41,7 +41,7 @@ def _parse_static_node_value(node):
         values = map(_parse_static_node_value, node.values)
         value = OrderedDict(zip(keys, values))
         # value = dict(zip(keys, values))
-    elif isinstance(node, (ast.NameConstant)):
+    elif isinstance(node, (ast.Constant)):
         value = node.value
     else:
         raise TypeError('Cannot parse a static value from non-static node '


### PR DESCRIPTION
A number of ast nodes were removed in python3.14 (https://docs.python.org/3.14/whatsnew/3.14.html#removed). This makes mkinit compatible with python 3.14