### PR TITLE
Add --source-order to preserve source order instead of alphabetizing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,7 +237,7 @@ Running ``mkint --help`` displays:
 
 
     usage: python -m mkinit [-h] [--dry] [-i] [--diff] [--noattrs] [--nomods] [--noall] [--relative] [--lazy | --lazy_loader] [--black] [--lazy_boilerplate LAZY_BOILERPLATE] [--recursive] [--norespect_all]
-                            [--verbose [VERBOSE]] [--version]
+                            [--source-order] [--verbose [VERBOSE]] [--version]
                             [modname_or_path]
 
     Autogenerate an `__init__.py` that exposes a top-level API.
@@ -287,6 +287,11 @@ Running ``mkint --help`` displays:
                             Code that defines a custom lazy_import callable
       --recursive           If specified, runs mkinit on all subpackages in a package
       --norespect_all       if False does not respect __all__ attributes of submodules when parsing
+      --source-order        Preserve the order in which symbols appear in their source module
+                            (and the order of submodules in __submodules__) instead of sorting
+                            names alphabetically. Note that submodules discovered implicitly
+                            (i.e. when __submodules__ is unspecified) are still ordered
+                            alphabetically.
       --verbose [VERBOSE]   Verbosity level
       --version             print version and exit
 

--- a/mkinit/__main__.py
+++ b/mkinit/__main__.py
@@ -172,7 +172,9 @@ def main():
         help=(
             'Preserve the order in which symbols appear in their source '
             'module (and the order of submodules in __submodules__) instead '
-            'of sorting names alphabetically'
+            'of sorting names alphabetically. Note that submodules '
+            'discovered implicitly (i.e. when __submodules__ is unspecified) '
+            'are still ordered alphabetically.'
         ),
     )
 

--- a/mkinit/__main__.py
+++ b/mkinit/__main__.py
@@ -164,6 +164,19 @@ def main():
     )
 
     parser.add_argument(
+        '--source-order',
+        '--source_order',
+        dest='source_order',
+        action='store_true',
+        default=False,
+        help=(
+            'Preserve the order in which symbols appear in their source '
+            'module (and the order of submodules in __submodules__) instead '
+            'of sorting names alphabetically'
+        ),
+    )
+
+    parser.add_argument(
         '--verbose', nargs='?', default=0, type=int, help='Verbosity level'
     )
 
@@ -221,6 +234,7 @@ def main():
         'lazy_loader_typed': ns['lazy_loader_typed'],
         'lazy_boilerplate': ns['lazy_boilerplate'],
         'use_black': ns['black'],
+        'source_order': ns['source_order'],
     }
 
     diff = ns['diff']

--- a/mkinit/formatting.py
+++ b/mkinit/formatting.py
@@ -407,7 +407,8 @@ def _initstr(
         exposed_from_imports = raw_from_imports
     elif protected:
         exposed_from_imports = [
-            (m, set(sub) & protected) for m, sub in raw_from_imports
+            (m, [a for a in sub if a in protected])
+            for m, sub in raw_from_imports
         ]
     exposed_from_imports = [(m, sub) for m, sub in exposed_from_imports if sub]
     exposed_all.update(

--- a/mkinit/formatting.py
+++ b/mkinit/formatting.py
@@ -39,6 +39,7 @@ def _ensure_options(given_options=None):
         'lazy_loader_typed': False,
         'lazy_boilerplate': None,
         'use_black': False,
+        'source_order': False,
     }
     options = default_options.copy()
     for k in given_options.keys():
@@ -422,8 +423,29 @@ def _initstr(
     if module_property_names:
         exposed_all.update(module_property_names)
 
-    exposed_all = sorted(exposed_all)
-    exposed_submodules = sorted(exposed_submodules)
+    if options.get('source_order', False):
+        # Preserve the order in which submodules and their attributes appear,
+        # following the order of submodules in __submodules__ (reflected by the
+        # `imports` order) and the source order of names within each submodule.
+        ordered_names = list(submod_to_import.keys())
+        for _, _sub in exposed_from_imports:
+            ordered_names.extend(_sub)
+        ordered_names.extend(explicit)
+        if module_property_names:
+            ordered_names.extend(module_property_names)
+
+        _seen = set()
+        exposed_all = [
+            n
+            for n in ordered_names
+            if n in exposed_all and not (n in _seen or _seen.add(n))
+        ]
+        exposed_submodules = [
+            m for m in submod_to_import.keys() if m in exposed_submodules
+        ]
+    else:
+        exposed_all = sorted(exposed_all)
+        exposed_submodules = sorted(exposed_submodules)
 
     def append_part(new_part):
         """appends a new part if it is nonempty"""
@@ -530,7 +552,7 @@ def _initstr(
                 """
                 ).rstrip()
             )
-        exports_repr = ["'{}'".format(e) for e in sorted(exposed_all)]
+        exports_repr = ["'{}'".format(e) for e in exposed_all]
         rhs_body = ', '.join(exports_repr)
         packed = _packed_rhs_text('__all__ = [', rhs_body + ']')
         append_part(packed)

--- a/mkinit/static_mkinit.py
+++ b/mkinit/static_mkinit.py
@@ -189,6 +189,8 @@ def static_init(
     """
     modpath = _rectify_to_modpath(modpath_or_name)
 
+    options = _ensure_options(options)
+
     user_decl = parse_user_declarations(modpath)
     logger.debug('user_decl = {}'.format(user_decl))
     if submodules is not None:
@@ -236,6 +238,7 @@ def static_init(
         respect_all=respect_all,
         external=external,
         ignore=ignore,
+        source_order=options['source_order'],
     )
 
     logger.debug('Found {} imports'.format(len(imports)))
@@ -557,7 +560,12 @@ def _extract_attributes(modpath=None, source=None, respect_all=True):
 
 
 def _static_parse_imports(
-    modpath, submodules=None, external=None, respect_all=True, ignore=None
+    modpath,
+    submodules=None,
+    external=None,
+    respect_all=True,
+    ignore=None,
+    source_order=False,
 ):
     """
     Search local submodules for names that should be exposed in the top-level
@@ -601,6 +609,10 @@ def _static_parse_imports(
         >>> print('from_imports = {!r}'.format(from_imports))
         >>> # assert 'autogen_init' in submodules
     """
+    def _ordered(attrs):
+        """Sort alphabetically unless source order is requested"""
+        return list(attrs) if source_order else sorted(attrs)
+
     logger.debug('Parse static submodules: {}'.format(modpath))
     # FIXME: handle the case where the __init__.py file doesn't exist yet
     modname = util_import.modpath_to_modname(modpath, check=False)
@@ -693,7 +705,7 @@ def _static_parse_imports(
                 if ignore:
                     ignore = set(ignore)
                     valid_attrs = [v for v in valid_attrs if v not in ignore]
-                from_imports.append(('.' + rel_modname, sorted(valid_attrs)))
+                from_imports.append(('.' + rel_modname, _ordered(valid_attrs)))
         else:
             # Determine which attrs were given as a pattern
             implicit_attrs = {a for a in attr_list if '*' in a}
@@ -714,7 +726,19 @@ def _static_parse_imports(
                 resolved_attrs = set()
                 resolved_attrs.update(explicit_attrs)
                 resolved_attrs.update(matched_attrs)
-                attr_list = sorted(resolved_attrs)
+                if source_order and extracted_attrs is not None:
+                    # Order by the position each name appears in the source,
+                    # appending any explicit names not found in the module.
+                    in_source = [
+                        a for a in extracted_attrs if a in resolved_attrs
+                    ]
+                    leftover = [
+                        a for a in attr_list if a in resolved_attrs
+                        and a not in extracted_attrs
+                    ]
+                    attr_list = in_source + leftover
+                else:
+                    attr_list = sorted(resolved_attrs)
 
             valid_attrs = attr_list
             if ignore:
@@ -740,6 +764,6 @@ def _static_parse_imports(
                     'Failed to parse {!r}, ex = {!r}'.format(ext_modname, ex)
                 )
             else:
-                from_imports.append((ext_modname, sorted(valid_attrs)))
+                from_imports.append((ext_modname, _ordered(valid_attrs)))
 
     return modname, imports, from_imports

--- a/tests/test_with_dummy.py
+++ b/tests/test_with_dummy.py
@@ -689,6 +689,53 @@ def test_ignore_filtering():
         assert 'PUBLIC_VAR' in import_line[0], 'PUBLIC_VAR should be included'
 
 
+def test_source_order():
+    """Test that source_order preserves declaration order instead of sorting."""
+    import re
+
+    import mkinit
+
+    cache_dpath = ub.Path.appdir('mkinit/tests').ensuredir()
+    root = ub.ensuredir(join(cache_dpath, 'test_source_order_pkg'))
+    ub.delete(root)
+    ub.ensuredir(root)
+
+    # Names are deliberately declared in non-alphabetical order
+    ub.Path(join(root, 'zebra.py')).write_text(
+        'def zulu(): pass\ndef alpha(): pass\ndef mike(): pass\n'
+    )
+    ub.Path(join(root, 'apple.py')).write_text(
+        'def yankee(): pass\ndef bravo(): pass\n'
+    )
+    ub.Path(join(root, '__init__.py')).write_text(
+        "__submodules__ = ['zebra', 'apple']\n"
+    )
+
+    def parse_all(text):
+        match = re.search(r'__all__ = \[(.*?)\]', text, flags=re.DOTALL)
+        assert match is not None, 'expected an __all__ variable'
+        return [
+            part.strip().strip('\'"')
+            for part in match.group(1).split(',')
+            if part.strip()
+        ]
+
+    # Default behavior alphabetizes everything
+    text = mkinit.static_init(root)
+    assert parse_all(text) == [
+        'alpha', 'apple', 'bravo', 'mike', 'yankee', 'zebra', 'zulu',
+    ]
+
+    # source_order follows __submodules__ order and in-module source order
+    text = mkinit.static_init(root, options={'source_order': True})
+    assert parse_all(text) == [
+        'zebra', 'apple', 'zulu', 'alpha', 'mike', 'yankee', 'bravo',
+    ]
+    assert 'import (zulu, alpha, mike,)' in text
+    assert 'import (yankee, bravo,)' in text
+    assert text.index('import zebra') < text.index('import apple')
+
+
 if __name__ == '__main__':
     """
     CommandLine:


### PR DESCRIPTION
## Summary
By default, mkinit alphabetizes generated imports and `__all__`. This adds an opt-in `--source-order` flag (also `--source_order`, or `options={'source_order': True}` via the Python API) that instead preserves:

- the order of submodules as listed in `__submodules__` (implicitly discovered submodules remain alphabetical), and
- the order in which attributes appear in each submodule's source — or the `__all__` declaration order when a submodule defines `__all__`.

This is useful when the source ordering is intentional (e.g. grouping related functions) and the generated `__init__.py` / docs should reflect it.

## Example
`python -m mkinit tests/mkinit_dummy_module --source-order` produces

    __all__ = ['subdir1', 'submod1', 'submod2', 'func1', 'func2', 'class1', 'class2']

instead of the default alphabetical ordering.

## Changes
- `mkinit/__main__.py`: new `--source-order` argparse flag, threaded into the options dict. Help text also notes that implicitly discovered submodules (no `__submodules__` declared) remain alphabetized.
- `mkinit/formatting.py`: `source_order` option (default `False`); when set, `_initstr` reconstructs `exposed_all` and `exposed_submodules` in source/declaration order (with dedup) instead of sorting. Also fixes a latent nondeterminism: the `--nomodattrs` + `__protected__` combination built attribute lists via set intersection (`set(sub) & protected`), which loses source order and is subject to hash-randomization jitter; switched to an order-preserving filter so `source_order` mode is deterministic there too.
- `mkinit/static_mkinit.py`: `_static_parse_imports` gains a `source_order` parameter; attribute lists from `_extract_attributes` (which already walks the AST in source order) are passed through unsorted, and explicit attrs matched against patterns are ordered by their position in the source.
- `tests/test_with_dummy.py`: new `test_source_order` test — builds a package with submodules and attributes declared out of alphabetical order, and asserts default output is alphabetized while `--source-order` output follows `__submodules__` order and in-source attribute order.
- `README.rst`: documented `--source-order` in the CLI usage/options reference, including the implicit-submodule caveat.

## Behavior notes
- Default behavior is unchanged — output without the flag is identical.
- Explicit attr names not found in the module are appended after source-ordered names, in the order given.
- Implicitly discovered submodules (no `__submodules__`) are still alphabetized even under `--source-order`.

## Testing
- `pytest tests/` — 26 passed (previously 25; new `test_source_order` added).
- Manual check: ran the `--nomodattrs` + `__protected__` + `--source-order` combination three times to confirm the previously set-based ordering is now stable across runs.